### PR TITLE
[NFC] New Interpreter interface for LLVM Backend

### DIFF
--- a/src/ast_walk_interpreter.rs
+++ b/src/ast_walk_interpreter.rs
@@ -5,61 +5,17 @@ use ast::*;
 use value::*;
 use operations;
 use environment::Environment;
-use typechecker::Type;
 use function::*;
+use runtime::*;
 
-#[derive(Debug, PartialEq)]
-pub enum RuntimeError {
-    /// When an undeclared identifier is used on the RHS
-    ReferenceError(String),
-    /// When an undeclared identifier is assigned to
-    UndeclaredAssignment(String),
-    /// When a binary op cannot be performed on the given types
-    BinaryTypeError(BinaryOp, Type, Type),
-    /// When a unary op cannot be performed on the given type
-    UnaryTypeError(UnaryOp, Type),
-    /// When a non-returning function's return value is used
-    NoneError(Option<String>),
-    /// When a call is made to a non-function value
-    CallToNonFunction(Option<String>, Type),
-    /// When the number of arguments don't match
-    ArgumentLength(Option<String>),
-    /// When nothing else suits
-    GeneralRuntimeError(String),
-    /// When a runtime error occurs inside a function call and is getting propagated as a plain RuntimeError
-    InsideFunctionCall(Box<RuntimeErrorWithPosition>),
-}
-
-pub type RuntimeErrorWithPosition = (RuntimeError, OffsetSpan);
-
-#[derive(Debug, PartialEq)]
-pub enum StatementResult {
-    None,
-    Break,
-    Value(Value),
-    Return(Option<Value>),
-}
-
-pub struct Interpreter {
+pub struct AstWalkInterpreter {
     pub root_env: Rc<RefCell<Environment>>,
 }
 
-impl Interpreter {
-    pub fn new() -> Interpreter {
-        Interpreter { root_env: Environment::new_root() }
-    }
 
-    pub fn run_ast_as_program(&mut self,
-                              program: &[StatementNode])
-                              -> Result<Option<StatementResult>, RuntimeErrorWithPosition> {
-        interpret_program(program, self.root_env.clone())
-    }
-
-    pub fn run_ast_as_statements
-        (&mut self,
-         statements: &[StatementNode])
-         -> Result<Option<StatementResult>, RuntimeErrorWithPosition> {
-        interpret_statements(statements, self.root_env.clone())
+impl AstWalkInterpreter {
+    pub fn new() -> AstWalkInterpreter {
+        AstWalkInterpreter { root_env: Environment::new_root() }
     }
 }
 
@@ -383,4 +339,20 @@ fn check_args_compat(arg_vals: &[Value],
         return Err((RuntimeError::ArgumentLength(None), expr.pos));
     }
     Ok(())
+}
+
+impl Interpreter for AstWalkInterpreter {
+
+    fn run_ast_as_statements
+        (&mut self,
+         statements: &[StatementNode])
+         -> Result<Option<StatementResult>, RuntimeErrorWithPosition> {
+        interpret_statements(statements, self.root_env.clone())
+    }
+
+    fn run_ast_as_program(&mut self,
+                              program: &[StatementNode])
+                              -> Result<Option<StatementResult>, RuntimeErrorWithPosition> {
+        interpret_program(program, self.root_env.clone())
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,7 +96,7 @@ fn offset_to_line_and_col(input: &str, pos: usize) -> (usize, usize) {
     (line_num, remaining + 1)
 }
 
-use interpreter::RuntimeError;
+use runtime::RuntimeError;
 use typechecker::TypeCheckerIssue;
 
 fn adjust_source_span(span: &mut SourceSpan, file_content: &str) {

--- a/src/function.rs
+++ b/src/function.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use value::*;
 use ast;
 use environment::Environment;
-use interpreter::RuntimeError;
+use runtime::RuntimeError;
 
 #[derive(Clone, Debug)]
 pub struct CallSign {
@@ -55,7 +55,8 @@ pub fn native_println(args: Vec<Value>) -> Result<(), RuntimeError> {
 #[allow(needless_pass_by_value)]
 pub fn native_run_http_server(args: Vec<Value>) -> Result<(), RuntimeError> {
     use std::net::{TcpListener, Shutdown};
-    use interpreter::call_func;
+    // TODO: refactor this to not call into ast_walk_interpreter
+    use ast_walk_interpreter::call_func;
     use std::io::Write;
 
     let ref handler_val = args[0];

--- a/src/interpreter_test.rs
+++ b/src/interpreter_test.rs
@@ -1,6 +1,7 @@
 use parser;
-use interpreter::Interpreter;
-use interpreter::StatementResult;
+use runtime::Interpreter;
+use runtime::StatementResult;
+use ast_walk_interpreter::AstWalkInterpreter;
 use value::Value;
 use value::Number;
 
@@ -15,8 +16,23 @@ fn run_and_get_last_result(code: &str) -> StatementResult {
     let ast = parser::program(code);
     match ast {
         Ok(ast) => {
-            let mut machine = Interpreter::new();
-            machine.run_ast_as_program(&ast).unwrap().unwrap()
+            let mut ast_walk_interpreter = AstWalkInterpreter::new();
+            let reference_val = ast_walk_interpreter.run_ast_as_program(&ast)
+                .unwrap().unwrap();
+            return reference_val
+            /*
+             * Test plan forward once LLVM backend is written
+            let mut llvm_interpreter = LLVMInterpreter::new()
+            let llvm_val = llvm_interpreter.run_ast_as_program(&ast)
+                .unwrap().unwrap();
+
+            if (llvm_val == reference_val) {
+                reference_val
+            }
+            else {
+                panic!("LLVM value: {:?} does not agree with Reference Value {:?}"
+            }
+            */
         }
         Err(_) => panic!("{:?}", ast),
     }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,6 +1,6 @@
 use value::*;
 use ast::{BinaryOp, UnaryOp};
-use interpreter::RuntimeError;
+use runtime::RuntimeError;
 
 pub fn unary_minus(a: Value) -> Result<Value, RuntimeError> {
     match a {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,15 +1,16 @@
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 
-use interpreter::*;
+use runtime::*;
 use error::*;
 use parser;
-use interpreter::StatementResult;
+use runtime::StatementResult;
 
-pub fn run_repl() {
+pub fn run_repl<T : Interpreter>(mut machine: T) {
     println!("Balloon REPL");
     let mut rl = Editor::<()>::new();
-    let mut machine = Interpreter::new();
+    // let mut machine = Interpreter::new();
+
     let file_name = "repl".to_string();
     loop {
         let readline = rl.readline("> ");

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,45 @@
+use ast::*;
+use value::*;
+use typechecker::Type;
+
+#[derive(Debug, PartialEq)]
+pub enum RuntimeError {
+    /// When an undeclared identifier is used on the RHS
+    ReferenceError(String),
+    /// When an undeclared identifier is assigned to
+    UndeclaredAssignment(String),
+    /// When a binary op cannot be performed on the given types
+    BinaryTypeError(BinaryOp, Type, Type),
+    /// When a unary op cannot be performed on the given type
+    UnaryTypeError(UnaryOp, Type),
+    /// When a non-returning function's return value is used
+    NoneError(Option<String>),
+    /// When a call is made to a non-function value
+    CallToNonFunction(Option<String>, Type),
+    /// When the number of arguments don't match
+    ArgumentLength(Option<String>),
+    /// When nothing else suits
+    GeneralRuntimeError(String),
+    /// When a runtime error occurs inside a function call and is getting propagated as a plain RuntimeError
+    InsideFunctionCall(Box<RuntimeErrorWithPosition>),
+}
+
+pub type RuntimeErrorWithPosition = (RuntimeError, OffsetSpan);
+
+#[derive(Debug, PartialEq)]
+pub enum StatementResult {
+    None,
+    Break,
+    Value(Value),
+    Return(Option<Value>),
+}
+
+pub trait Interpreter {
+    fn run_ast_as_statements
+        (&mut self,
+         statements: &[StatementNode])
+         -> Result<Option<StatementResult>, RuntimeErrorWithPosition>;
+    fn run_ast_as_program(&mut self,
+                              program: &[StatementNode])
+                              -> Result<Option<StatementResult>, RuntimeErrorWithPosition>;
+}

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 
 use ast::*;
 use ast;
-use interpreter::RuntimeError;
+use runtime::RuntimeError;
 use function::*;
 
 #[derive(Clone, Debug)]

--- a/src/typechecker_test.rs
+++ b/src/typechecker_test.rs
@@ -1,7 +1,7 @@
 use parser;
 use typechecker::check_program;
 use typechecker::{TypeCheckerIssue, TypeCheckerIssueWithPosition};
-use interpreter::RuntimeError;
+use runtime::RuntimeError;
 use typechecker::Type;
 use ast::*;
 


### PR DESCRIPTION
Split the old Interpreter struct into a trait: `Interpreter`
and a struct: `AstWalkInterpreter`

Will start to add functionality for LLVM backend.