### PR TITLE
Run updated rustfmt v0.8.3, add rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+array_layout = "Block"
+
+# I'd like to have this, but right now it does weird things
+# fn_call_style = "Block"

--- a/src/ast_walk_interpreter.rs
+++ b/src/ast_walk_interpreter.rs
@@ -316,7 +316,12 @@ pub fn call_func(func: &Function, arg_vals: &[Value]) -> Result<Option<Value>, R
             Ok(None)
         }
         Function::NativeReturning(_, ref native_fn) => Ok(Some(native_fn(arg_vals.to_vec())?)),
-        Function::User { ref param_names, ref body, ref env, .. } => {
+        Function::User {
+            ref param_names,
+            ref body,
+            ref env,
+            ..
+        } => {
             // TODO: returning
             let function_env = Environment::create_child(env.clone());
             for (param, arg) in param_names.iter().zip(arg_vals.iter()) {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -23,28 +23,29 @@ pub struct Environment {
 impl Environment {
     pub fn new_root() -> Rc<RefCell<Environment>> {
         let mut env = Environment::new();
-        let builtin_functions = &[("println",
-                                   Function::NativeVoid(CallSign {
-                                                            num_params: 0,
-                                                            variadic: true,
-                                                            param_types: vec![],
-                                                        },
-                                                        native_println)),
-                                  ("run_http_server",
-                                   Function::NativeVoid(CallSign {
-                                                            num_params: 1,
-                                                            variadic: false,
-                                                            param_types:
-                                                                vec![Some(ConstraintType::Function)],
-                                                        },
-                                                        native_run_http_server)),
-                                  ("len",
-                                   Function::NativeReturning(CallSign {
-                                                                 num_params: 1,
-                                                                 variadic: false,
-                                                                 param_types: vec![None],
-                                                             },
-                                                             native_len))];
+        let builtin_functions = &[
+            ("println",
+             Function::NativeVoid(CallSign {
+                                      num_params: 0,
+                                      variadic: true,
+                                      param_types: vec![],
+                                  },
+                                  native_println)),
+            ("run_http_server",
+             Function::NativeVoid(CallSign {
+                                      num_params: 1,
+                                      variadic: false,
+                                      param_types: vec![Some(ConstraintType::Function)],
+                                  },
+                                  native_run_http_server)),
+            ("len",
+             Function::NativeReturning(CallSign {
+                                           num_params: 1,
+                                           variadic: false,
+                                           param_types: vec![None],
+                                       },
+                                       native_len)),
+        ];
         for item in builtin_functions.iter() {
             let (name, ref func) = *item;
             env.declare(&name.to_string(), &Value::Function(Box::new(func.clone())));
@@ -68,7 +69,8 @@ impl Environment {
     }
 
     pub fn declare(&mut self, identifier: &str, value: &Value) {
-        self.symbol_table.insert(identifier.to_owned(), value.clone());
+        self.symbol_table
+            .insert(identifier.to_owned(), value.clone());
     }
 
     pub fn set(&mut self, identifier: &str, value: Value) -> bool {

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,7 +105,11 @@ fn adjust_source_span(span: &mut SourceSpan, file_content: &str) {
     }
     while (span.end_col == 0) && span.end_line > span.start_line {
         span.end_line -= 1;
-        span.end_col = file_content.lines().nth(span.end_line - 1).unwrap().len();
+        span.end_col = file_content
+            .lines()
+            .nth(span.end_line - 1)
+            .unwrap()
+            .len();
     }
 }
 
@@ -287,14 +291,16 @@ pub fn print_typechecker_error_for_file(err: TypeCheckerIssue,
             .unwrap();
         println!("{}{}", left_padding, Yellow.bold().paint(pointer_string));
     } else {
-        let first_line_start_bytes = file_content.lines()
+        let first_line_start_bytes = file_content
+            .lines()
             .nth(span.start_line - 1)
             .unwrap()
             .bytes()
             .take(span.start_col - 1)
             .collect::<Vec<u8>>();
         let first_line_start_string = str::from_utf8(&first_line_start_bytes).unwrap();
-        let first_line_rest_bytes = file_content.lines()
+        let first_line_rest_bytes = file_content
+            .lines()
             .nth(span.start_line - 1)
             .unwrap()
             .bytes()
@@ -314,20 +320,23 @@ pub fn print_typechecker_error_for_file(err: TypeCheckerIssue,
 
         for line_num in span.start_line..span.end_line - 1 {
             println!("{line_num:width$} | {}",
-                     Red.bold().paint(file_content.lines().nth(line_num).unwrap()),
+                     Red.bold()
+                         .paint(file_content.lines().nth(line_num).unwrap()),
                      line_num = line_num + 1,
                      width = max_idx_width);
         }
 
         if span.end_col != 0 {
-            let last_line_start_bytes = file_content.lines()
+            let last_line_start_bytes = file_content
+                .lines()
                 .nth(span.end_line - 1)
                 .unwrap()
                 .bytes()
                 .take(span.end_col)
                 .collect::<Vec<u8>>();
             let last_line_start_string = str::from_utf8(&last_line_start_bytes).unwrap();
-            let last_line_rest_bytes = file_content.lines()
+            let last_line_rest_bytes = file_content
+                .lines()
                 .nth(span.end_line - 1)
                 .unwrap()
                 .bytes()

--- a/src/function.rs
+++ b/src/function.rs
@@ -84,7 +84,7 @@ pub fn native_run_http_server(args: Vec<Value>) -> Result<(), RuntimeError> {
         Value::Function(ref f) => f,
         _ => {
             return Err(RuntimeError::GeneralRuntimeError("http_server: handler is not a Function"
-                .to_owned()))
+                                                             .to_owned()))
         }
     };
 
@@ -145,7 +145,7 @@ pub fn native_run_http_server(args: Vec<Value>) -> Result<(), RuntimeError> {
                         return Err(RuntimeError::GeneralRuntimeError("http_server: handler \
                                                                       function did not return a \
                                                                       value"
-                            .to_owned()));
+                                                                             .to_owned()));
                     }
                     Some(val) => val,
                 };
@@ -153,7 +153,7 @@ pub fn native_run_http_server(args: Vec<Value>) -> Result<(), RuntimeError> {
                     return Err(RuntimeError::GeneralRuntimeError("http_server: threading error \
                                                                   (could not send on reverse \
                                                                   channel)"
-                        .to_owned()));
+                                                                         .to_owned()));
                 }
             }
         }

--- a/src/interpreter_test.rs
+++ b/src/interpreter_test.rs
@@ -17,7 +17,8 @@ fn run_and_get_last_result(code: &str) -> StmtResult {
     match ast {
         Ok(ast) => {
             let mut ast_walk_interpreter = AstWalkInterpreter::new();
-            let reference_val = ast_walk_interpreter.run_ast_as_program(&ast)
+            let reference_val = ast_walk_interpreter
+                .run_ast_as_program(&ast)
                 .unwrap()
                 .unwrap();
             return reference_val;
@@ -179,9 +180,11 @@ fn id_in_expr() {
 #[test]
 fn create_tuple() {
     assert_eq!(run_and_get_last_value("(1, 2, 3);"),
-               Value::Tuple(vec![Value::Number(Number::Integer(1)),
-                                 Value::Number(Number::Integer(2)),
-                                 Value::Number(Number::Integer(3))]));
+               Value::Tuple(vec![
+        Value::Number(Number::Integer(1)),
+        Value::Number(Number::Integer(2)),
+        Value::Number(Number::Integer(3)),
+    ]));
 }
 
 #[test]

--- a/src/llvm_interpreter.rs
+++ b/src/llvm_interpreter.rs
@@ -229,7 +229,13 @@ fn add_c_declarations(module: &mut Module) -> CDeclarations {
 
     add_function(module,
                  "llvm.memset.p0i8.i32",
-                 &mut [int8_ptr_type(), int8_type(), int32_type(), int32_type(), int1_type()],
+                 &mut [
+        int8_ptr_type(),
+        int8_type(),
+        int32_type(),
+        int32_type(),
+        int1_type(),
+    ],
                  void);
 
     let malloc = add_function(module, "malloc", &mut [int32_type()], int8_ptr_type());
@@ -415,8 +421,10 @@ fn gen_add_fn(mut module: &mut Module, box_unbox_functions: &BoxUnboxFunctions) 
         let fnname = "balloon_add";
         let addfn = add_function(module,
                                  fnname,
-                                 &mut [LLVMPointerType(box_type(), 0),
-                                       LLVMPointerType(box_type(), 0)],
+                                 &mut [
+            LLVMPointerType(box_type(), 0),
+            LLVMPointerType(box_type(), 0),
+        ],
                                  LLVMPointerType(box_type(), 0));
         let bb = LLVMAppendBasicBlock(addfn, module.new_string_ptr("entry"));
         builder.position_at_end(bb);
@@ -720,7 +728,9 @@ impl LLVMJIT {
             LLVMVerifyModule(module.module,
                              LLVMVerifierFailureAction::LLVMAbortProcessAction,
                              &mut error_c_string);
-            let err = CStr::from_ptr(error_c_string).to_string_lossy().into_owned();
+            let err = CStr::from_ptr(error_c_string)
+                .to_string_lossy()
+                .into_owned();
             println!("@@@@@@ ERROR: {}", err);
 
             let engine: *mut LLVMExecutionEngineRef = mem::uninitialized();

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -182,24 +182,26 @@ impl fmt::Debug for TypeEnvironment {
 impl TypeEnvironment {
     pub fn new_root() -> Rc<RefCell<TypeEnvironment>> {
         let mut env = TypeEnvironment::new();
-        let builtin_functions = &[("println",
-                                   FunctionType::NativeVoid(CallSign {
-                                       num_params: 0,
-                                       variadic: true,
-                                       param_types: vec![],
-                                   })),
-                                  ("len",
-                                   FunctionType::NativeReturning(CallSign {
-                                       num_params: 1,
-                                       variadic: false,
-                                       param_types: vec![None],
-                                   })),
-                                  ("run_http_server",
-                                   FunctionType::NativeVoid(CallSign {
-                                       num_params: 1,
-                                       variadic: false,
-                                       param_types: vec![Some(ConstraintType::Function)],
-                                   }))];
+        let builtin_functions = &[
+            ("println",
+             FunctionType::NativeVoid(CallSign {
+                                          num_params: 0,
+                                          variadic: true,
+                                          param_types: vec![],
+                                      })),
+            ("len",
+             FunctionType::NativeReturning(CallSign {
+                                               num_params: 1,
+                                               variadic: false,
+                                               param_types: vec![None],
+                                           })),
+            ("run_http_server",
+             FunctionType::NativeVoid(CallSign {
+                                          num_params: 1,
+                                          variadic: false,
+                                          param_types: vec![Some(ConstraintType::Function)],
+                                      })),
+        ];
         for item in builtin_functions.iter() {
             let (name, ref func) = *item;
             env.declare(&name.to_string(),
@@ -601,8 +603,9 @@ fn check_expr_unary_op(op: &UnOp,
     match check_expr(expr, env.clone()) {
         Ok(None) => {
             if let Expr::FnCall(ref id, _) = expr.data {
-                return Err(vec![(RuntimeError::NoneError(try_get_name_of_fn(id)).into(),
-                                 expr.pos)]);
+                return Err(vec![
+                    (RuntimeError::NoneError(try_get_name_of_fn(id)).into(), expr.pos),
+                ]);
             }
             unreachable!();
         }
@@ -627,8 +630,9 @@ fn check_expr_unary_logical_op(op: &LogicalUnOp,
     match check_expr(expr, env.clone()) {
         Ok(None) => {
             if let Expr::FnCall(ref id, _) = expr.data {
-                return Err(vec![(RuntimeError::NoneError(try_get_name_of_fn(id)).into(),
-                                 expr.pos)]);
+                return Err(vec![
+                    (RuntimeError::NoneError(try_get_name_of_fn(id)).into(), expr.pos),
+                ]);
             }
             unreachable!();
         }
@@ -801,7 +805,9 @@ fn check_expr_function_call(expr: &ExprNode,
     let func_call_sign = func_type.get_call_sign();
     if !func_call_sign.variadic && arg_types.len() != func_type.get_call_sign().param_types.len() {
         if let Expr::Identifier(ref id) = expr.data {
-            return Err(vec![(RuntimeError::ArgumentLength(Some(id.clone())).into(), expr.pos)]);
+            return Err(vec![
+                (RuntimeError::ArgumentLength(Some(id.clone())).into(), expr.pos),
+            ]);
         } else {
             return Err(vec![(RuntimeError::ArgumentLength(None).into(), expr.pos)]);
         }
@@ -810,12 +816,14 @@ fn check_expr_function_call(expr: &ExprNode,
             issues.append(&mut e);
         }
 
-        if let FunctionType::User { ref param_names,
-                                    ref body,
-                                    ref env,
-                                    ref already_checked_param_types,
-                                    ref ret_type,
-                                    .. } = func_type {
+        if let FunctionType::User {
+                   ref param_names,
+                   ref body,
+                   ref env,
+                   ref already_checked_param_types,
+                   ref ret_type,
+                   ..
+               } = func_type {
             let function_env = TypeEnvironment::create_child(env.clone());
             for (param, arg) in param_names.iter().zip(arg_types.iter()) {
                 function_env.borrow_mut().declare(param, arg);
@@ -830,7 +838,8 @@ fn check_expr_function_call(expr: &ExprNode,
                     let new_func_type =
                         get_function_type_with_updated_already_checked(&func_type,
                                                                        new_checked_param_types);
-                    env.borrow_mut().set(&id, Type::Function(Box::new(Some(new_func_type))));
+                    env.borrow_mut()
+                        .set(&id, Type::Function(Box::new(Some(new_func_type))));
 
                     let mut context = Context {
                         in_loop: false,
@@ -939,7 +948,7 @@ fn check_expr_member_access_by_index(expr: &ExprNode,
         Ok(None) => {
             if let Expr::FnCall(ref id, _) = index_expr.data {
                 issues.push((RuntimeError::NoneError(try_get_name_of_fn(id)).into(),
-                                index_expr.pos));
+                             index_expr.pos));
             }
         }
         Ok(Some(typ)) => {
@@ -1038,14 +1047,16 @@ fn check_args_compat(arg_types: &[Type],
 fn get_function_type_with_updated_already_checked(
     old_fn_type: &FunctionType,
     new_already_checked: LinearMap<Vec<ConstraintType>,()>)
-    -> FunctionType {
+-> FunctionType{
 
-    if let FunctionType::User { ref param_names,
-                                ref body,
-                                ref env,
-                                ref call_sign,
-                                ref ret_type,
-                                .. } = *old_fn_type {
+    if let FunctionType::User {
+               ref param_names,
+               ref body,
+               ref env,
+               ref call_sign,
+               ref ret_type,
+               ..
+           } = *old_fn_type {
         FunctionType::User {
             param_names: param_names.clone(),
             body: body.clone(),

--- a/src/typechecker_test.rs
+++ b/src/typechecker_test.rs
@@ -26,8 +26,10 @@ fn check_no_reference_error() {
 fn check_reference_error() {
     let result = check_and_get_result("var x = 5; y;");
     assert_eq!(result.unwrap_err(),
-               [(TypeCheckerIssue::RuntimeError(RuntimeError::ReferenceError("y".to_owned())),
-                 (11, 12))]);
+               [
+        (TypeCheckerIssue::RuntimeError(RuntimeError::ReferenceError("y".to_owned())),
+         (11, 12)),
+    ]);
 }
 
 #[test]
@@ -54,24 +56,30 @@ fn check_no_binary_type_error() {
 fn check_binary_type_error_add() {
     let result = check_and_get_result("1 + true;");
     assert_eq!(result.unwrap_err(),
-               [(TypeCheckerIssue::RuntimeError(RuntimeError::BinaryTypeError(BinOp::Add,
-                                                                              Type::Number,
-                                                                              Type::Bool)),
-                 (0, 8))]);
+               [
+        (TypeCheckerIssue::RuntimeError(RuntimeError::BinaryTypeError(BinOp::Add,
+                                                                      Type::Number,
+                                                                      Type::Bool)),
+         (0, 8)),
+    ]);
 
     let result = check_and_get_result("true + 1;");
     assert_eq!(result.unwrap_err(),
-               [(TypeCheckerIssue::RuntimeError(RuntimeError::BinaryTypeError(BinOp::Add,
-                                                                              Type::Bool,
-                                                                              Type::Number)),
-                 (0, 8))]);
+               [
+        (TypeCheckerIssue::RuntimeError(RuntimeError::BinaryTypeError(BinOp::Add,
+                                                                      Type::Bool,
+                                                                      Type::Number)),
+         (0, 8)),
+    ]);
 
     let result = check_and_get_result("false + true;");
     assert_eq!(result.unwrap_err(),
-               [(TypeCheckerIssue::RuntimeError(RuntimeError::BinaryTypeError(BinOp::Add,
-                                                                              Type::Bool,
-                                                                              Type::Bool)),
-                 (0, 12))]);
+               [
+        (TypeCheckerIssue::RuntimeError(RuntimeError::BinaryTypeError(BinOp::Add,
+                                                                      Type::Bool,
+                                                                      Type::Bool)),
+         (0, 12)),
+    ]);
 }
 
 #[test]
@@ -84,16 +92,20 @@ fn check_no_unary_minus_error() {
 fn check_unary_minus_error() {
     let result = check_and_get_result("-false;");
     assert_eq!(result.unwrap_err(),
-               [(TypeCheckerIssue::RuntimeError(RuntimeError::UnaryTypeError(UnOp::Neg,
-                                                                             Type::Bool)),
-                 (1, 6))]);
+               [
+        (TypeCheckerIssue::RuntimeError(RuntimeError::UnaryTypeError(UnOp::Neg,
+                                                                     Type::Bool)),
+         (1, 6)),
+    ]);
 }
 
 #[test]
 fn check_multiple_types_from_branch() {
     let result = check_and_get_result("var x = 5; if true { x = true; } else { x = 10; } ");
     assert_eq!(result.unwrap_err(),
-               [(TypeCheckerIssue::MultipleTypesFromBranchWarning("x".to_owned()), (11, 50))]);
+               [
+        (TypeCheckerIssue::MultipleTypesFromBranchWarning("x".to_owned()), (11, 50)),
+    ]);
 }
 
 #[test]
@@ -115,17 +127,21 @@ fn check_arg_mismatch_fail() {
 fn check_arg_mismatch_pass() {
     let result = check_and_get_result("fn f(x) {} f();");
     assert_eq!(result.unwrap_err(),
-               [((TypeCheckerIssue::RuntimeError(RuntimeError::ArgumentLength(None))), (11, 14))]);
+               [
+        ((TypeCheckerIssue::RuntimeError(RuntimeError::ArgumentLength(None))), (11, 14)),
+    ]);
 }
 
 #[test]
 fn check_type_error_in_fn() {
     let result = check_and_get_result("fn f() { true + 1; }");
     assert_eq!(result.unwrap_err(),
-               [(TypeCheckerIssue::RuntimeError(RuntimeError::BinaryTypeError(BinOp::Add,
-                                                                              Type::Bool,
-                                                                              Type::Number)),
-                 (9, 17))]);
+               [
+        (TypeCheckerIssue::RuntimeError(RuntimeError::BinaryTypeError(BinOp::Add,
+                                                                      Type::Bool,
+                                                                      Type::Number)),
+         (9, 17)),
+    ]);
 }
 
 #[test]
@@ -138,8 +154,10 @@ fn check_no_reference_error_in_fn() {
 fn check_reference_error_in_fn() {
     let result = check_and_get_result("fn f() { x; }");
     assert_eq!(result.unwrap_err(),
-               [(TypeCheckerIssue::RuntimeError(RuntimeError::ReferenceError("x".to_owned())),
-                 (9, 10))]);
+               [
+        (TypeCheckerIssue::RuntimeError(RuntimeError::ReferenceError("x".to_owned())),
+         (9, 10)),
+    ]);
 }
 
 #[test]
@@ -155,14 +173,18 @@ if 1 {
     x = 5;
 }");
     assert_eq!(result.unwrap_err(),
-               [(TypeCheckerIssue::MultipleTypesFromBranchWarning("x".to_owned()), (22, 81))]);
+               [
+        (TypeCheckerIssue::MultipleTypesFromBranchWarning("x".to_owned()), (22, 81)),
+    ]);
 }
 
 #[test]
 fn check_non_integral_subscript() {
     assert_eq!(check_and_get_result("(1, 2, 3)[true];").unwrap_err(),
-               [(TypeCheckerIssue::RuntimeError(RuntimeError::NonIntegralSubscript(Type::Bool)),
-                 (10, 14))]);
+               [
+        (TypeCheckerIssue::RuntimeError(RuntimeError::NonIntegralSubscript(Type::Bool)),
+         (10, 14)),
+    ]);
 }
 
 #[test]
@@ -211,9 +233,11 @@ fn check_return_type() {
     return true;
 }";
     assert_eq!(check_and_get_result(code).unwrap_err(),
-               [(TypeCheckerIssue::ReturnTypeMismatch(Some(ConstraintType::Number),
-                                                      Some(ConstraintType::Bool)),
-                 (27, 40))]);
+               [
+        (TypeCheckerIssue::ReturnTypeMismatch(Some(ConstraintType::Number),
+                                              Some(ConstraintType::Bool)),
+         (27, 40)),
+    ]);
 }
 
 #[test]


### PR DESCRIPTION
0.8.3 or some earlier version seems to have brought in some changes to
the default style - with more block indentation instead of the earlier
vertical column. Personally, I prefer this given the shorter length of
lines as well as familiarity from different languages.

In addition, a rustfmt.toml is added in this commit that also makes the
array style block, which doesn't seem to be one of the defaults yet.