### PR TITLE
Massively refactor return type checking, inferred instead of explicit

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,7 +1,5 @@
 use std::fmt;
 
-use typechecker::ConstraintType;
-
 pub type OffsetSpan = (usize, usize);
 
 #[derive(Debug, Clone, PartialEq)]
@@ -112,9 +110,8 @@ pub enum BindingType {
 #[derive(Debug, Clone)]
 pub struct FnDefExpr {
     pub maybe_id: Option<String>,
-    pub params: Vec<(String, Option<ConstraintType>)>,
+    pub params: Vec<String>,
     pub body: Box<StmtNode>,
-    pub maybe_ret_type: Option<ConstraintType>,
 }
 
 #[derive(Debug, Clone)]
@@ -125,7 +122,6 @@ pub enum Expr {
     BinaryLogical(Box<ExprNode>, LogicalBinOp, Box<ExprNode>),
     Unary(UnOp, Box<ExprNode>),
     UnaryLogical(LogicalUnOp, Box<ExprNode>),
-    // optional name, list of params, body, optional return type
     FnDef(FnDefExpr),
     FnCall(Box<ExprNode>, Vec<ExprNode>),
     Tuple(Vec<ExprNode>),

--- a/src/ast_walk_interpreter.rs
+++ b/src/ast_walk_interpreter.rs
@@ -9,7 +9,6 @@ use environment::Environment;
 use function::*;
 use runtime::*;
 use typechecker::Type;
-use typechecker::ConstraintType;
 
 #[derive(Clone)]
 struct Context {
@@ -409,18 +408,13 @@ impl AstWalkInterpreter {
                  ref maybe_id,
                  ref params,
                  ref body,
-                 ref maybe_ret_type,
              } = fn_def_expr;
-        let (param_names, param_types): (Vec<String>, Vec<Option<ConstraintType>>) =
-            params.iter().cloned().unzip();
         let func = Function::User {
-            ret_type: maybe_ret_type.clone(),
             call_sign: CallSign {
                 num_params: params.len(),
                 variadic: false,
-                param_types: param_types,
             },
-            param_names: param_names.clone(),
+            param_names: params.clone(),
             body: body.clone(),
             env: self.env.clone(),
         };

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -5,7 +5,6 @@ use fnv::FnvHashMap;
 
 use value::*;
 use function::*;
-use typechecker::ConstraintType;
 
 #[derive(Debug)]
 pub struct Environment {
@@ -28,21 +27,18 @@ impl Environment {
              Function::NativeVoid(CallSign {
                                       num_params: 0,
                                       variadic: true,
-                                      param_types: vec![],
                                   },
                                   native_println)),
             ("run_http_server",
              Function::NativeVoid(CallSign {
                                       num_params: 1,
                                       variadic: false,
-                                      param_types: vec![Some(ConstraintType::Function)],
                                   },
                                   native_run_http_server)),
             ("len",
              Function::NativeReturning(CallSign {
                                            num_params: 1,
                                            variadic: false,
-                                           param_types: vec![None],
                                        },
                                        native_len)),
         ];

--- a/src/function.rs
+++ b/src/function.rs
@@ -5,13 +5,11 @@ use value::*;
 use ast;
 use environment::Environment;
 use runtime::RuntimeError;
-use typechecker::ConstraintType;
 
 #[derive(Clone, Debug)]
 pub struct CallSign {
     pub num_params: usize,
     pub variadic: bool,
-    pub param_types: Vec<Option<ConstraintType>>,
 }
 
 #[derive(Clone, Debug)]
@@ -19,7 +17,6 @@ pub enum Function {
     NativeVoid(CallSign, fn(Vec<Value>) -> Result<(), RuntimeError>),
     NativeReturning(CallSign, fn(Vec<Value>) -> Result<Value, RuntimeError>),
     User {
-        ret_type: Option<ConstraintType>,
         call_sign: CallSign,
         param_names: Vec<String>,
         body: Box<ast::StmtNode>,

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -1,5 +1,4 @@
 use ast::*;
-use typechecker::ConstraintType;
 
 pub program -> Vec<StmtNode>
     = __ terminators? s:statements { s }
@@ -71,41 +70,21 @@ function_definition_node -> ExprNode
     = __ lpos:#position f:function_definition rpos:#position __ { ExprNode { pos: (lpos, rpos), data: f } }
 
 function_definition -> Expr
-    = FN __ i:identifier? __ OPEN_PAREN __ params:param_list __ COMMA? __ CLOSE_PAREN __ maybe_ret_hint:return_type_hint? __ lpos:#position body:block rpos:#position __ {
-        let return_type = match maybe_ret_hint {
-            Some(ret_hint) => ret_hint,
-            None => Some(ConstraintType::Any),
-        };
+    = FN __ i:identifier? __ OPEN_PAREN __ params:param_list __ COMMA? __ CLOSE_PAREN __ lpos:#position body:block rpos:#position __ {
         Expr::FnDef(
             FnDefExpr {
                 maybe_id: i,
                 params: params,
                 body: Box::new(StmtNode { pos: (lpos, rpos), data: body } ),
-                maybe_ret_type: return_type,
             }
         )
     }
 
-param_list -> Vec<(String, Option<ConstraintType>)>
-    = identifier_with_possible_type ** COMMA
+param_list -> Vec<String>
+    = identifier_with_whitespace ** COMMA
 
-identifier_with_possible_type -> (String, Option<ConstraintType>)
-    = __ id:identifier __ t:type_hint? __ { (id, t) }
-
-return_type_hint -> Option<ConstraintType>
-    = COLON __ VOID { None }
-    / COLON __ t:typ { Some(t) }
-
-type_hint -> ConstraintType
-    = COLON __ t:typ { t }
-
-typ -> ConstraintType
-    = NUMBER { ConstraintType::Number }
-    / BOOL { ConstraintType::Bool }
-    / STRING { ConstraintType::String }
-    / FUNCTION { ConstraintType::Function }
-    / TUPLE { ConstraintType::Tuple }
-    / ANY { ConstraintType::Any }
+identifier_with_whitespace -> String
+    = __ id:identifier __ { id }
 
 expr_node -> ExprNode
     = e:binary_expr_node { e }


### PR DESCRIPTION
- Remove enum ConstraintType, remove explicit type annotations.
- Identify return statements in function bodies, and use them to infer
  the return type for each call site (or rather, for each unique set
  of argument types).
- Correctly use the implied `return;` at the end of functions that are
  not unconditionally returning a value. Still TODO: give the
  FunctionReturnsMultipleTypes error in this case.

Closes #25.