### PR TITLE
Ignore files that look like *.ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 /target/
 
 *.bk
+
+# I use this for scripts that set my $PATH. Would be nice if it were
+# ignored by balloon.
+*.ignore


### PR DESCRIPTION
I use `*.ignore` files to setup my `LLVM` paths.

For example,

```
╰─$ cat set_llvm_paths.source.ignore
# source this file to setup paths correctly

export LLVM_SYS_40_PREFIX=~/work/LLVM-all/polly/llvm_40_build/install-out

export LLVM_40_PATH=/Users/bollu/work/LLVM-all/polly/llvm_40_build

export PATH=$LLVM_40_PATH/bin:$PATH
export DYLD_LIBRARY_PATH=$LLVM_40_PATH/lib:$DYLD_LIBRARY_PATH

export SIMPLEXHC_LOWERING_ROOT=/Users/bollu/work/simplexhc-llvm-lowering

export PATH=$SIMPLEXHC_LOWERING_ROOT:$PATH
export DYLD_LIBRARY_PATH=$SIMPLEXHC_LOWERING_ROOT/out:$DYLD_LIBRARY_PATH
```